### PR TITLE
Fix BtwQuests not opening on button tap

### DIFF
--- a/Code/SupportedAddons/Core/addon.Support.BtWQuests/Core/BtWQuests_Script.lua
+++ b/Code/SupportedAddons/Core/addon.Support.BtWQuests/Core/BtWQuests_Script.lua
@@ -358,17 +358,25 @@ function NS.Script:Load()
 
 		do -- FUNCTIONS
 			function Callback:OpenQuestInBtWQuestsWindow(questID)
-				local item = BtWQuestsDatabase:GetQuestItem(questID, BtWQuestsCharacters:GetPlayer())
-
+				--local item = BtWQuestsDatabase:GetQuestItem(questID, BtWQuestsCharacters:GetPlayer())
+				--------------------------------
+				--if item then
+				--	BtWQuestsFrame:SelectCharacter(UnitName("player"), GetRealmName())
+				--	BtWQuestsFrame:SelectItem(item.item)
+				--end
 				--------------------------------
 
-				if item then
-					BtWQuestsFrame:SelectCharacter(UnitName("player"), GetRealmName())
-					BtWQuestsFrame:SelectItem(item.item)
-				end
+				local questChain, questChainReferences = Callback:GetQuestChains()
+				local chainID = questChainReferences[questID]
 
-				--------------------------------
+				local Chain = BtWQuestsDatabase:GetChainByID(chainID);
 
+				local link = Chain:GetLink();
+				BtWQuestsFrame:Show();
+				C_Timer.After(0, function()
+					local scrollTo = nil;
+					BtWQuestsFrame:SelectFromLink(link, scrollTo);
+				end)
 				addon.Interaction.Script:Stop(true)
 			end
 		end


### PR DESCRIPTION
**Summary**
This PR fixes an issue where tapping the button to open a quest in BtwQuests did not work.

**Issue**
The Callback:OpenQuestInBtWQuestsWindow method attempted to retrieve a quest item directly using BtWQuestsDatabase:GetQuestItem, but this kept returned nil, preventing the BtwQuests window from opening at all.

**Fix**
Replaced the previous implementation with logic that resolves the quest’s chain ID using Callback:GetQuestChains() and opens the quest chain via BtWQuestsFrame:SelectFromLink. This guarantees the UI opens even if the direct item lookup fails.

New behavior

```
function Callback:OpenQuestInBtWQuestsWindow(questID)
    local questChain, questChainReferences = Callback:GetQuestChains()
    local chainID = questChainReferences[questID]
    local Chain = BtWQuestsDatabase:GetChainByID(chainID)

    local link = Chain:GetLink()
    BtWQuestsFrame:Show()
    C_Timer.After(0, function()
        local scrollTo = nil
        BtWQuestsFrame:SelectFromLink(link, scrollTo)
    end)
    addon.Interaction.Script:Stop(true)
end
```

**Tested**
    Confirmed that tapping the button now reliably opens BtwQuests and navigates to the correct quest chain.

Let me know if you'd like this gated behind a fallback, or some logic changes