### PR TITLE
Fixes Lua Error when loading Quest Chain ID #43

### DIFF
--- a/Code/SupportedAddons/Core/addon.Support.BtWQuests/Core/BtWQuests_Script.lua
+++ b/Code/SupportedAddons/Core/addon.Support.BtWQuests/Core/BtWQuests_Script.lua
@@ -170,12 +170,13 @@ function NS.Script:Load()
 			end
 
 			function Callback:GetChainIDFromQuest(questID)
-				local item = BtWQuestsDatabase:GetQuestItem(questID, BtWQuestsCharacters:GetPlayer()).item
-				local chainID = item.id
-				local chainType = item.type
-				local chainIndex = item.index
 
-				return chainID
+				local quest = BtWQuestsDatabase:GetQuestItem(questID, BtWQuestsCharacters:GetPlayer())
+				if quest then
+					if quest.item and type(quest.item) == "table" and quest.item.type == "chain" then
+						return quest.item.id
+					end
+				end
 			end
 
 			function Callback:GetChainInfoFromChainID(chainID)


### PR DESCRIPTION
**Summary**

This PR fixes a Lua error that occurred when calling Callback:GetChainIDFromQuest(questID) on quests that are not part of a registered quest chain.

**Root Cause**

The function assumed BtWQuestsDatabase:GetQuestItem would always return a valid quest object, and attempted to index it unconditionally. Some quests (e.g., Squire’s Spurs) returned nil, causing a runtime error.

**Error Example**

attempt to index global 'quest' (a nil value)

**Fix**

The method now checks if quest, quest.item, and quest.item.type are valid before attempting to access quest.item.id.

Updated Implementation
```
function Callback:GetChainIDFromQuest(questID)
    local quest = BtWQuestsDatabase:GetQuestItem(questID, BtWQuestsCharacters:GetPlayer())
    if quest then
        if quest.item and type(quest.item) == "table" and quest.item.type == "chain" then
            return quest.item.id
        end
    end
end
```

**Tested**

    Verified that quests not tied to a chain no longer trigger a Lua error

    Quests that do belong to chains continue to work as expected

**Addon Versions**

    Interaction: 0.1.5

    BtWQuests: 2.54.0

    WoW Client: 11.1.7