### PR TITLE
fix: Fixed dungeon interactions

### DIFF
--- a/Code/Modules/Core/Cinematic/Core/Cinematic_Script.lua
+++ b/Code/Modules/Core/Cinematic/Core/Cinematic_Script.lua
@@ -441,7 +441,7 @@ function NS.Script:Load()
 					return
 				end
 
-				local interactTargetIsSelf = ((UnitName("npc") == UnitName("player")) or UnitName("questnpc") == UnitName("player"))
+				local interactTargetIsSelf = (UnitIsUnit("npc", "player") or UnitIsUnit("questnpc", "player"))
 				local isStaticNPC = ((UnitName("npc") and not UnitExists("npc")) or (UnitName("questnpc") and not UnitExists("questnpc")))
 				local inInstance = (IsInInstance())
 				local isSkyriding = GetGlidingInfo and select(1, GetGlidingInfo()) or false
@@ -458,7 +458,7 @@ function NS.Script:Load()
 					return
 				end
 
-				local interactTargetIsSelf = ((UnitName("npc") == UnitName("player")) or UnitName("questnpc") == UnitName("player"))
+				local interactTargetIsSelf = (UnitIsUnit("npc", "player") or UnitIsUnit("questnpc", "player"))
 				local isStaticNPC = ((UnitName("npc") and not UnitExists("npc")) or (UnitName("questnpc") and not UnitExists("questnpc")))
 				local inInstance = (IsInInstance())
 

--- a/Code/Modules/Core/Cinematic/Core/Cinematic_Script.lua
+++ b/Code/Modules/Core/Cinematic/Core/Cinematic_Script.lua
@@ -492,6 +492,10 @@ function NS.Script:Load()
 
 				f:SetScript("OnEvent", function()
 					InteractionFrame.CinematicMode.Vignette:SetAlpha(0)
+
+					if NS.Variables.Active then
+						NS.Script:CancelCinematicMode(true)
+					end
 				end)
 			end
 		end)
@@ -508,7 +512,7 @@ function NS.Script:Load()
 				Frame.EasingDuration = 2
 
 				Frame:SetScript("OnUpdate", function(self, elapsed)
-					if NS.Variables.IsPanning then
+					if NS.Variables.IsPanning and not IsInCinematicScene() and not (MovieFrame and MovieFrame:IsShown()) then
 						do -- Easing
 							Frame.ElapsedTime = Frame.ElapsedTime + elapsed
 
@@ -562,7 +566,7 @@ function NS.Script:Load()
 
 		local f = CreateFrame("Frame")
 		f:SetScript("OnUpdate", function()
-			if NS.Variables.Active then
+			if NS.Variables.Active and not IsInCinematicScene() and not (MovieFrame and MovieFrame:IsShown()) then
 				do -- Offset
 					local speed = .025
 					local target

--- a/Code/Modules/Core/HideUI/Core/HideUI_Script.lua
+++ b/Code/Modules/Core/HideUI/Core/HideUI_Script.lua
@@ -109,8 +109,6 @@ function NS.Script:Load()
 
 		function NS.Script:StartInteraction()
 			if addon.Database.DB_GLOBAL.profile.INT_HIDEUI then
-				local interactTargetIsSelf = ((UnitName("npc") == UnitName("player")) or UnitName("questnpc") == UnitName("player"))
-				local isStaticNPC = ((UnitName("npc") and not UnitExists("npc")) or (UnitName("questnpc") and not UnitExists("questnpc")))
 				local inInstance = (IsInInstance())
 
 				if not inInstance then
@@ -125,8 +123,6 @@ function NS.Script:Load()
 
 		function NS.Script:StopInteraction()
 			if addon.Database.DB_GLOBAL.profile.INT_HIDEUI then
-				local interactTargetIsSelf = ((UnitName("npc") == UnitName("player")) or UnitName("questnpc") == UnitName("player"))
-				local isStaticNPC = ((UnitName("npc") and not UnitExists("npc")) or (UnitName("questnpc") and not UnitExists("questnpc")))
 				local inInstance = (IsInInstance())
 
 				if not inInstance and NS.Variables.Active then

--- a/Code/Modules/Core/Interaction/Modules/Dialog/Core/Dialog_Script.lua
+++ b/Code/Modules/Core/Interaction/Modules/Dialog/Core/Dialog_Script.lua
@@ -93,7 +93,7 @@ function NS.Script:Load()
 
 			function Frame:Style_MatchScrollCriteria()
 				local targetIsGameObject = (UnitIsGameObject("npc") or UnitIsGameObject("questnpc"))
-				local targetIsSelf = ((UnitName("npc") == UnitName("player")) or UnitName("questnpc") == UnitName("player"))
+				local targetIsSelf = (UnitIsUnit("npc", "player") or UnitIsUnit("questnpc", "player"))
 				local targetIsItem = (addon.API.Util:FindItemInInventory(UnitName("npc") or "Empty Result") or addon.API.Util:FindItemInInventory(UnitName("questnpc") or "Empty Result"))
 
 				if targetIsGameObject or targetIsSelf or targetIsItem then
@@ -106,7 +106,7 @@ function NS.Script:Load()
 			function Frame:UpdateStyle()
 				local info = NS.Variables.info
 				local interactTargetNameplate = ((C_NamePlate.GetNamePlateForUnit("npc") or C_NamePlate.GetNamePlateForUnit("questnpc")))
-				local interactTargetIsSelf = ((UnitName("npc") == UnitName("player")) or UnitName("questnpc") == UnitName("player"))
+				local interactTargetIsSelf = (UnitIsUnit("npc", "player") or UnitIsUnit("questnpc", "player"))
 
 				if info.contentInfo.full then
 					if info.contentInfo.emoteIndexes[NS.Variables.Playback_Index] then NS.Variables.Style_IsEmote = true else NS.Variables.Style_IsEmote = false end
@@ -1148,10 +1148,7 @@ function NS.Script:Load()
 				if addon.Interaction.Variables.Active then
 					local button = ...
 
-					local targetName = UnitName("npc") or UnitName("questnpc")
-					local mouseOverName = UnitName("mouseover")
-
-					if tostring(targetName) == tostring(mouseOverName) then
+					if UnitIsUnit("mouseover", "npc") or UnitIsUnit("mouseover", "questnpc") then
 						Frame:OnMouseUp(button, false)
 					end
 				end


### PR DESCRIPTION
This changes resolve #84, #85 and #86.

This pull request refactors several code sections to improve reliability and readability by replacing string-based unit comparisons with the more robust `UnitIsUnit` API. This change helps ensure that unit identity checks are accurate and less error-prone, especially in edge cases where unit names may not be unique or may change.

**Refactoring target identity checks:**
* Replaced all instances of direct string comparison between `UnitName("npc")`/`UnitName("questnpc")` and `UnitName("player")` with calls to `UnitIsUnit("npc", "player")` or `UnitIsUnit("questnpc", "player")` in `Cinematic_Script.lua` and `Dialog_Script.lua` for more reliable unit identity checks. [[1]](diffhunk://#diff-de0d048612975ca1cfeb82ed6c605c5a2e6d4082b09f82f0146a9f64d88a6387L444-R444) [[2]](diffhunk://#diff-de0d048612975ca1cfeb82ed6c605c5a2e6d4082b09f82f0146a9f64d88a6387L461-R461) [[3]](diffhunk://#diff-fef2be9b39a9c5b43faa2226a7115f35f16afe2c43851258d9d8635897a34529L96-R96) [[4]](diffhunk://#diff-fef2be9b39a9c5b43faa2226a7115f35f16afe2c43851258d9d8635897a34529L109-R109)
* Updated mouseover target comparison in `Dialog_Script.lua` to use `UnitIsUnit("mouseover", "npc")` or `UnitIsUnit("mouseover", "questnpc")` instead of comparing string names, ensuring correct identification of the hovered unit.

**Code cleanup:**
* Removed now-unnecessary local variables that relied on string-based unit checks in `HideUI_Script.lua`, simplifying the logic in `StartInteraction` and `StopInteraction`. [[1]](diffhunk://#diff-1289dab4aa150750665ceb2d64abc4965edbc0b476eea81b0129b73c976cd474L112-L113) [[2]](diffhunk://#diff-1289dab4aa150750665ceb2d64abc4965edbc0b476eea81b0129b73c976cd474L128-L129)


EDIT: Currently produces an error with cutscenes (when starting while the interface is opened)